### PR TITLE
add simple localStorage capability. closes #1

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,15 +10,16 @@
 
 </head>
 
-<body>
+<body onload="reloadVars()">
   <header>
     <h1 id="gamename">Game Title</h1>
   </header>
-
+  
   <nav>
     <button type="button" onclick="addGameName()">Add Game name</button>
     <button type="button" onclick="addPlayers()">Add team names</button>
     <button type="button" onclick="document.getElementById('scores').innerHTML='500 &emsp; &emsp; 300 &emsp; &emsp; 900'">Add Scores</button>
+    <button type="button" onclick="clearCache()">Clear Game</button>
   </nav>
 
   <table id="scoreTable" style="width:80%">
@@ -26,16 +27,28 @@
   </table>
 
   <script>
-  function addGameName() {
-      var gametext = prompt("Please enter name of Game", "Mille Bornes");
+  function addGameName(promptPlayer=true) {
+      var gametext = localStorage.getItem('OSC-gametext');
+
+      if (gametext == null && promptPlayer) {
+          gametext = prompt("Please enter name of Game", "Mille Bornes");
+      }
       if (gametext != null) {
           document.getElementById("gamename").innerHTML =
           gametext;
+          localStorage.setItem('OSC-gametext',gametext);
       }
   }
-  function addPlayers(){
-      var numPlayersPrompt = prompt("Please enter the number of players/teams, integer input only");
+  function addPlayers(promptPlayer=true){
+      var playerName;
+      var numPlayersPrompt = localStorage.getItem('OSC-numPlayers');
+
+      if (numPlayersPrompt == null && promptPlayer) {
+          numPlayersPrompt = prompt("Please enter the number of players/teams, integer input only");
+      }
+
       var numPlayers = parseInt(numPlayersPrompt);
+      localStorage.setItem('OSC-numPlayers',numPlayersPrompt);
         if (numPlayers != null) {
           var table = document.getElementById("scoreTable");
           var teamrow = table.insertRow(0);
@@ -45,9 +58,36 @@
           for (var i = 0; i < numPlayers; i++) {
               j++;
               cellinput = teamrow.insertCell(i);
-              cellinput.innerHTML = prompt("Enter name for team " + j);
+              playerName = localStorage.getItem('OSC-player'+i.toString());
+              if (playerName == null) {
+                  cellinput.innerHTML = prompt("Enter name for team " + j);
+              } 
+              else {
+                  cellinput.innerHTML = playerName;
+              }            
               teams.push(cellinput.innerHTML);
+              localStorage.setItem('OSC-player'+i.toString(),cellinput.innerHTML);
           }
+      }
+  }
+  function clearCache(){
+      var numPlayers = localStorage.getItem('OSC-numPlayers');
+      for (var i=0; i< numPlayers; i++) {
+          localStorage.removeItem('OSC-player'+i.toString());
+      }
+      localStorage.removeItem('OSC-gametext');
+      localStorage.removeItem('OSC-numPlayers');
+      location.reload();
+  }
+  function reloadVars(){
+      var varOSC;
+      varOSC = localStorage.getItem('OSC-gametext');
+      if (varOSC != null) {
+          addGameName(false);
+      }
+      varOSC = localStorage.getItem('OSC-numPlayers');
+      if (varOSC != null) {
+         addPlayers(false);
       }
   }
   </script>


### PR DESCRIPTION
see #1 

several things going on here.

1) onreload of the page, fires off the new reloadVars() function that loops through the known saved LocalStorage variables (currently prefixed with OSC-_) and if they exist, call the Add_ functions.

2) added an optional input parameter to Add\* functions to allow user prompting or not. this defaults to TRUE so that previous behavior is maintained, but when reloadVars() calls these Add\* functions, it passes 'false' for the situation where there are no OSC-\* variables. There's most certainly a better way to do this.

3) when a variable is successfully set, save that variable to OSC-*.  note that is is kind of redundant for the situation where you reload from LocalStorage. i.e. you get OSC-gametext so you can set the gametext, then you go and set OSC-gametext again. This can and should be optimized at some future point, but figured it was too early for such optimization right now.

4) note that we aren't doing much error checking. we assume that if numPlayers = 3, there are exactly 3 OSC-player\* variables (see line 61). this isn't ideal, but it works.

5) scores don't seem to be working yet, so I didn't save them. we will probably want to look into better ways to scale this up since there will be a lot of lines of scores. we can simply append the i,j to the variable (i = num player, j = score row), but there could be a better way to do this later.
